### PR TITLE
Set up Cursor Cloud dev environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a Rust Cargo workspace implementing a multiplayer rock-paper-scissors
+game, plus a Next.js web client. Build/lint/test/run commands are standard and
+documented below only where non-obvious.
+
+### Services
+
+| Service | Path | Run command (from repo root) | Ports | Notes |
+| --- | --- | --- | --- | --- |
+| game-server | `src/game-server` | `cargo run -p game-server` | REST `8082`, game WS `3002` | See blocking bug below — standalone binary panics on startup. |
+| matchmaking-server | `src/matchmaking-server` | `cargo run -p matchmaking-server` | queue WS `3001`, REST `8081` | Opens `matchmaking.db` (SQLite) in the current working dir; calls game-server at `http://0.0.0.0:8082`. |
+| web-client | `src/web-client` | `pnpm -C src/web-client dev` | HTTP `3030` | Next.js dev server. Connects to matchmaking WS at `ws://localhost:3001` (hardcoded). |
+| agent | `src/agent` | `cargo run -p agent` | — | Stub, `main()` is empty. |
+
+`src/common` is a shared library, not a runnable service. All addresses are
+hardcoded in the binaries' `main.rs` (no env-var config).
+
+### Lint / test / build
+
+- Rust: `cargo build`, `cargo clippy`, `cargo test` from the repo root (workspace-wide). The `cargo test` suite stands up real game + matchmaking servers and plays a full game end-to-end; tests auto-create a temp SQLite DB from `sql/create_tables.sql`.
+- Web client: `pnpm -C src/web-client lint` and `pnpm -C src/web-client build`.
+
+### Required runtime setup (non-obvious)
+
+- The matchmaking-server does NOT auto-create its DB schema. Before running it (not needed for `cargo test`), initialize the DB in the repo root:
+  `sqlite3 matchmaking.db < sql/create_tables.sql`
+  The file `matchmaking.db` is gitignored.
+- Start order for a full live run: game-server (`8082`/`3002`) → matchmaking-server (`3001`/`8081`) → web-client (`3030`).
+- System packages required to build the Rust crates: `libsqlite3-dev` (for `rusqlite`, which links system SQLite) and `libssl-dev` (for `openssl-sys`). These are installed in the VM snapshot, not by the update script.
+
+### KNOWN BLOCKING BUG: game-server standalone binary panics
+
+`src/game-server/src/entrypoint.rs` `serve()` calls `ready_signal.unwrap()`
+unconditionally, but `src/game-server/src/main.rs` passes `None`, so
+`cargo run -p game-server` panics immediately with
+`called \`Option::unwrap()\` on a \`None\` value`. (The sibling
+`matchmaking-server` `serve()` correctly guards this with `if let Some(...)`.)
+
+Consequences:
+- The game-server binary cannot run as-is, so a live full match cannot complete in the browser.
+- When two players match, matchmaking-server POSTs to game-server `/create_game`; with game-server down this fails with `Connection refused` and the matchmaking-server's matchmaking task then panics (`matchmaking.rs` uses `.expect(...)`). The matchmaking-server stays up only while no two players match.
+
+The fix is a one-liner mirroring matchmaking-server: replace
+`ready_signal.unwrap().send(())...` with
+`if let Some(ready_signal) = ready_signal { ready_signal.send(()).expect(...); }`.
+This was intentionally NOT changed during environment setup (no app-code edits);
+the workspace test suite (`cargo test`) exercises the full game flow regardless,
+because the test path passes `Some(ready_sender)`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Rust workspace + Next.js web client and documents it for future Cloud agents. No application code was modified.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section: service map, ports, lint/test/build/run commands, required runtime setup (SQLite schema init, system libs), and a prominent known bug.
- Registers a minimal update script (`cargo fetch`; `pnpm -C src/web-client install`).

## Environment

- System packages installed in the VM: `libsqlite3-dev` (needed by `rusqlite`), `libssl-dev` (needed by `openssl-sys`). Rust `1.83.0` toolchain present (workspace builds fine; Dockerfile pins `1.85.0`).
- Web client uses `pnpm` (Node 22).

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Rust build | `cargo build` | pass |
| Rust lint | `cargo clippy` | pass (warnings only) |
| Rust tests (full RPS game e2e) | `cargo test` | pass |
| Web lint | `pnpm -C src/web-client lint` | pass (warnings only) |
| matchmaking-server | `cargo run -p matchmaking-server` | runs (WS `3001`, REST `8081`) |
| web-client | `pnpm -C src/web-client dev` | runs (HTTP `3030`) |

Browser demo: two clients join the matchmaking queue over a live WebSocket connection and receive `JoinedQueue`.

<a href="https://cursor.com/agents/bc-3d18d909-c106-4128-89f1-a33bc40befec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_client_join_queue_demo.mp4"><img src="https://cursor.com/artifacts/c/art-7e6c69d9-ba37-474c-bbd3-84e3304092a0" alt="web_client_join_queue_demo.mp4" /></a>
![Two clients in queue](https://cursor.com/artifacts/c/art-9d1817c6-8d1b-4838-bff0-877cc80921e4)

## Known blocking bug (not fixed here — no app-code edits during env setup)

`src/game-server/src/entrypoint.rs` `serve()` calls `ready_signal.unwrap()`, but `src/game-server/src/main.rs` passes `None`, so `cargo run -p game-server` panics immediately. The sibling `matchmaking-server` guards this with `if let Some(...)`. Because game-server can't run standalone, a live full match cannot complete in the browser (matchmaking-server then panics on the `create_game` call with `Connection refused`). The full game flow is still proven by `cargo test`, whose code path passes `Some(ready_sender)`. See `AGENTS.md` for the one-line fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d18d909-c106-4128-89f1-a33bc40befec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d18d909-c106-4128-89f1-a33bc40befec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

